### PR TITLE
Update signer.ts

### DIFF
--- a/src/signers/signer.ts
+++ b/src/signers/signer.ts
@@ -20,14 +20,19 @@ export abstract class Signer {
   async sign(tx: Transaction): Promise<Transaction> {
     const messages = this.toMessages(tx);
     const witnesses = await this.signMessages(messages);
-    witnesses[0] = new Reader(
-      SerializeWitnessArgs(
-        normalizers.NormalizeWitnessArgs({
-          ...tx.witnessArgs[0],
-          lock: witnesses[0],
-        })
-      )
-    ).serializeJson();
+    for (let i = 0; i < witnesses.length; i++) {
+      if (witnesses[i] === undefined || witnesses[i] == "0x") {
+          continue
+      }
+      witnesses[i] = new Reader(
+        SerializeWitnessArgs(
+          normalizers.NormalizeWitnessArgs({
+            ...tx.witnessArgs[i],
+            lock: witnesses[i],
+          })
+        )
+      ).serializeJson();
+    }
     tx = FillSignedWitnesses(tx, messages, witnesses);
 
     return tx;

--- a/src/signers/signer.ts
+++ b/src/signers/signer.ts
@@ -22,7 +22,7 @@ export abstract class Signer {
     const witnesses = await this.signMessages(messages);
     for (let i = 0; i < witnesses.length; i++) {
       if (witnesses[i] === undefined || witnesses[i] === "0x") {
-          continue
+          continue;
       }
       witnesses[i] = new Reader(
         SerializeWitnessArgs(

--- a/src/signers/signer.ts
+++ b/src/signers/signer.ts
@@ -21,7 +21,7 @@ export abstract class Signer {
     const messages = this.toMessages(tx);
     const witnesses = await this.signMessages(messages);
     for (let i = 0; i < witnesses.length; i++) {
-      if (witnesses[i] === undefined || witnesses[i] == "0x") {
+      if (witnesses[i] === undefined || witnesses[i] === "0x") {
           continue
       }
       witnesses[i] = new Reader(


### PR DESCRIPTION
支持部分签名，允许Input0不带签名

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix: 如果不需要签名的cell放在input list的前面，无法支持


* **What is the current behavior?** (You can also link to an open issue here)
不支持


* **What is the new behavior (if this is a feature change)?**
支持部分签名，免签名的cell允许放在前面
        const tx = new Transaction(new RawTransaction(inputCells, outputCells, dependCells,headerDeps), [
            "0x",
            "0x",
            Builder.WITNESS_ARGS.Secp256k1,
        ]);

* **Other information**:
无