### PR TITLE
fix: ios13 compatibility

### DIFF
--- a/src/ckb-lumos/since.js
+++ b/src/ckb-lumos/since.js
@@ -129,7 +129,7 @@ function validateSince(since, tipSinceValidationInfo, cellSinceValidationInfo) {
         throw new Error(`Must provide tip median_timestamp!`);
       }
 
-      return value * 1000n <= BigInt(tipSinceValidationInfo.median_timestamp);
+      return value * BigInt(1000) <= BigInt(tipSinceValidationInfo.median_timestamp);
     }
   } else {
     if (type === "epochNumber") {
@@ -178,7 +178,7 @@ function validateSince(since, tipSinceValidationInfo, cellSinceValidationInfo) {
       }
 
       return (
-        value * 1000n + BigInt(cellSinceValidationInfo.median_timestamp) <=
+        value * BigInt(1000) + BigInt(cellSinceValidationInfo.median_timestamp) <=
         BigInt(tipSinceValidationInfo.median_timestamp)
       );
     }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

ios13 breaks.

https://demo-unipass-me-5w4ape5y9-lay2.vercel.app/#/

* **What is the current behavior?** (You can also link to an open issue here)

ios13 works.


* **What is the new behavior (if this is a feature change)?**

remove bigint literial.

* **Other information**:
