### PR TITLE
feat: CKB2021 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@scatterjs/core": "^2.7.53",
     "@scatterjs/eosjs2": "^1.5.35",
     "axios": "^0.19.2",
-    "bech32": "^1.1.4",
+    "bech32": "2.0.0",
     "blake2b": "^2.1.3",
     "bs58": "^4.0.1",
     "cross-fetch": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "node": ">=8.9"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-utils": "^0.41.1",
+    "@nervosnetwork/ckb-sdk-utils": "0.101.0",
     "@scatterjs/core": "^2.7.53",
     "@scatterjs/eosjs2": "^1.5.35",
     "axios": "^0.19.2",

--- a/src/helpers/address.ts
+++ b/src/helpers/address.ts
@@ -1,0 +1,15 @@
+export enum NervosAddressVersion {
+  latest,
+  pre2021,
+  ckb2021,
+}
+
+export function getConcreteNervosAddressVersion(
+  addressVersion: NervosAddressVersion
+) {
+  if (addressVersion === NervosAddressVersion.pre2021) {
+    return addressVersion;
+  }
+
+  return NervosAddressVersion.ckb2021;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,5 +13,6 @@ export * from './constants';
 export * from './ckb-js-toolkit';
 export * from './ckb-lumos';
 export * from './helpers/ckb-indexer';
+export * from './helpers/address';
 
 export default PWCore;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -9,6 +9,7 @@ export interface CKBModel {
 export enum HashType {
   data = 'data',
   type = 'type',
+  data1 = 'data1',
 }
 
 export enum DepType {

--- a/src/models/address.spec.ts
+++ b/src/models/address.spec.ts
@@ -26,7 +26,7 @@ const tronAddress = new Address(tron, AddressType.tron);
 const network = {
   blockchain: 'eos',
   chainId: 'aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906',
-  host: 'eospush.tokenpocket.pro',
+  host: 'mainnet.eosamsterdam.net',
   port: 80,
   protocol: 'http',
 };

--- a/src/models/address.spec.ts
+++ b/src/models/address.spec.ts
@@ -6,10 +6,13 @@ import { EosProvider } from '../providers';
 import { DummyProvider } from '../providers/dummy-provider';
 import { Script } from './script';
 import { HashType } from '../interfaces';
+import { NervosAddressVersion } from '..';
 
 const eth = '0x32f4c2df50f678a94609e98f8ee7ffb14b6799bc';
-const ckb = 'ckt1qyqxpayn272n8km2k08hzldynj992egs0waqnr8zjs';
-const ckbFull =
+
+const ckbAddress1StringFullPre2021 =
+  'ckt1q3vvtay34wndv9nckl8hah6fzzcltcqwcrx79apwp2a5lkd07fdxxvh5ct04panc49rqn6v03mnllv2tv7vmc9kkmjq';
+const ckbAddress1StringFull2021 =
   'ckt1qpvvtay34wndv9nckl8hah6fzzcltcqwcrx79apwp2a5lkd07fdxxqfj7npd758k0z55vz0f378w0la3fdnen0qj5grsu';
 
 const eos = 'sking1234511';
@@ -19,8 +22,24 @@ const tron = 'TNV2p8Zmy5JcZWbtn59Qee8jTdGmCRC6e8';
 const tronFull =
   'ckt1qpvvtay34wndv9nckl8hah6fzzcltcqwcrx79apwp2a5lkd07fdxxqvfg4auqnw9z7ek5clnlasfa9dz3txesqq3pm97m';
 
-const ckbAddress = new Address(ckb, AddressType.ckb);
-const ckbFullAddress = new Address(ckbFull, AddressType.ckb);
+const ckbAddress1FullPre2021 = new Address(
+  ckbAddress1StringFullPre2021,
+  AddressType.ckb
+);
+const ckbAddress1Full2021 = new Address(
+  ckbAddress1StringFull2021,
+  AddressType.ckb
+);
+
+const ckbAddress2StringShortPre2021 =
+  'ckt1qyqxpayn272n8km2k08hzldynj992egs0waqnr8zjs';
+const ckbAddress2StringFull2021 =
+  'ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqtq7jf409fnmd4t8nm30kjfezj4v5g8hwskhal6m';
+const ckbAddress2ShortPre2021 = new Address(
+  ckbAddress2StringShortPre2021,
+  AddressType.ckb
+);
+
 const ethAddress = new Address(eth, AddressType.eth);
 let eosAddress;
 const tronAddress = new Address(tron, AddressType.tron);
@@ -54,23 +73,51 @@ test('to address and type', (t) => {
   t.is(ethAddress.addressString, eth);
   t.is(ethAddress.addressType, AddressType.eth);
 
-  t.is(ckbAddress.addressString, ckb);
-  t.is(ckbAddress.addressType, AddressType.ckb);
+  t.is(ckbAddress2ShortPre2021.addressString, ckbAddress2StringShortPre2021);
+  t.is(ckbAddress2ShortPre2021.addressType, AddressType.ckb);
 
   t.is(eosAddress.addressString, eos);
   t.is(eosAddress.addressType, AddressType.eos);
 
   t.is(tronAddress.addressString, tron);
   t.is(tronAddress.addressType, AddressType.tron);
-
-  t.is(ckbFullAddress.addressString, ckbFull);
-  t.is(ckbFullAddress.addressType, AddressType.ckb);
 });
 
-test('to ckb address', (t) => {
-  t.is(ethAddress.toCKBAddress(), ckbFull);
-  t.is(ckbFullAddress.toCKBAddress(), ckbFull);
-  t.is(ckbAddress.toCKBAddress(), ckb);
+test('addressString for AddressType.ckb by default returns address passed class in constructor', (t) => {
+  t.is(ckbAddress1Full2021.addressString, ckbAddress1StringFull2021);
+  t.is(ckbAddress1Full2021.addressType, AddressType.ckb);
+
+  t.is(ckbAddress1FullPre2021.addressString, ckbAddress1StringFullPre2021);
+  t.is(ckbAddress1FullPre2021.addressType, AddressType.ckb);
+
+  t.is(ckbAddress2ShortPre2021.addressString, ckbAddress2StringShortPre2021);
+  t.is(ckbAddress2ShortPre2021.addressType, AddressType.ckb);
+});
+
+test('"toCKBAddress" correctly transforms preckb2021 address to desired version', (t) => {
+  t.is(ckbAddress1FullPre2021.toCKBAddress(), ckbAddress1StringFull2021);
+  t.is(
+    ckbAddress1FullPre2021.toCKBAddress(NervosAddressVersion.latest),
+    ckbAddress1StringFull2021
+  );
+  t.is(
+    ckbAddress1FullPre2021.toCKBAddress(NervosAddressVersion.ckb2021),
+    ckbAddress1StringFull2021
+  );
+  t.is(
+    ckbAddress1FullPre2021.toCKBAddress(NervosAddressVersion.pre2021),
+    ckbAddress1StringFullPre2021
+  );
+});
+
+test('"toCKBAddress" general test', (t) => {
+  t.is(ethAddress.toCKBAddress(), ckbAddress1StringFull2021);
+  t.is(ckbAddress1Full2021.toCKBAddress(), ckbAddress1StringFull2021);
+  t.is(ckbAddress2ShortPre2021.toCKBAddress(), ckbAddress2StringFull2021);
+  t.is(
+    ckbAddress2ShortPre2021.toCKBAddress(NervosAddressVersion.pre2021),
+    ckbAddress2StringShortPre2021
+  );
 
   t.is(eosAddress.toCKBAddress(), eosFull);
   t.is(tronAddress.toCKBAddress(), tronFull);
@@ -104,13 +151,13 @@ test('to lock script', (t) => {
     hash_type: PWCore.config.pwLock.script.hashType,
   });
 
-  t.deepEqual(ckbAddress.toLockScript().serializeJson(), {
+  t.deepEqual(ckbAddress2ShortPre2021.toLockScript().serializeJson(), {
     args: '0x60f493579533db6ab3cf717da49c8a5565107bba',
     code_hash: PWCore.config.defaultLock.script.codeHash,
     hash_type: PWCore.config.defaultLock.script.hashType,
   });
 
-  t.deepEqual(ckbFullAddress.toLockScript().serializeJson(), {
+  t.deepEqual(ckbAddress1Full2021.toLockScript().serializeJson(), {
     args: '0x32f4c2df50f678a94609e98f8ee7ffb14b6799bc',
     code_hash: PWCore.config.pwLock.script.codeHash,
     hash_type: PWCore.config.pwLock.script.hashType,

--- a/src/models/address.spec.ts
+++ b/src/models/address.spec.ts
@@ -4,19 +4,20 @@ import { Address, AddressType } from './address';
 import { DummyCollector } from '../collectors/dummy-collector';
 import { EosProvider } from '../providers';
 import { DummyProvider } from '../providers/dummy-provider';
-import { AddressPrefix, HashType, Script } from '..';
+import { Script } from './script';
+import { HashType } from '../interfaces';
 
 const eth = '0x32f4c2df50f678a94609e98f8ee7ffb14b6799bc';
 const ckb = 'ckt1qyqxpayn272n8km2k08hzldynj992egs0waqnr8zjs';
 const ckbFull =
-  'ckt1q3vvtay34wndv9nckl8hah6fzzcltcqwcrx79apwp2a5lkd07fdxxvh5ct04panc49rqn6v03mnllv2tv7vmc9kkmjq';
+  'ckt1qpvvtay34wndv9nckl8hah6fzzcltcqwcrx79apwp2a5lkd07fdxxqfj7npd758k0z55vz0f378w0la3fdnen0qj5grsu';
 
 const eos = 'sking1234511';
 const eosFull =
-  'ckt1q3vvtay34wndv9nckl8hah6fzzcltcqwcrx79apwp2a5lkd07fdxxm6cetwv38anze52vznk9mz8dcwsjns4kdxuu6a';
+  'ckt1qpvvtay34wndv9nckl8hah6fzzcltcqwcrx79apwp2a5lkd07fdxxqt0tr9dejylkvtx3fs2wchvgahp6z2wzkcd3cuk8';
 const tron = 'TNV2p8Zmy5JcZWbtn59Qee8jTdGmCRC6e8';
 const tronFull =
-  'ckt1q3vvtay34wndv9nckl8hah6fzzcltcqwcrx79apwp2a5lkd07fdx8z2900qym3ghkd4x8ullvz0ftg52ekvqqtyehuu';
+  'ckt1qpvvtay34wndv9nckl8hah6fzzcltcqwcrx79apwp2a5lkd07fdxxqvfg4auqnw9z7ek5clnlasfa9dz3txesqq3pm97m';
 
 const ckbAddress = new Address(ckb, AddressType.ckb);
 const ckbFullAddress = new Address(ckbFull, AddressType.ckb);
@@ -75,6 +76,7 @@ test('to ckb address', (t) => {
   t.is(tronAddress.toCKBAddress(), tronFull);
 });
 
+// RFC: https://github.com/nervosnetwork/rfcs/pull/239
 test('to ckb2021 mainnet address (Nervos RFC21)', async (t) => {
   PWCore.chainId = ChainID.ckb;
 
@@ -84,8 +86,7 @@ test('to ckb2021 mainnet address (Nervos RFC21)', async (t) => {
         '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8',
         '0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64',
         HashType.type
-      ),
-      AddressPrefix.ckb
+      )
     ).addressString,
     new Address(
       'ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqdnnw7qkdnnclfkg59uzn8umtfd2kwxceqxwquc4',

--- a/src/models/address.spec.ts
+++ b/src/models/address.spec.ts
@@ -4,6 +4,7 @@ import { Address, AddressType } from './address';
 import { DummyCollector } from '../collectors/dummy-collector';
 import { EosProvider } from '../providers';
 import { DummyProvider } from '../providers/dummy-provider';
+import { AddressPrefix, HashType, Script } from '..';
 
 const eth = '0x32f4c2df50f678a94609e98f8ee7ffb14b6799bc';
 const ckb = 'ckt1qyqxpayn272n8km2k08hzldynj992egs0waqnr8zjs';
@@ -72,6 +73,27 @@ test('to ckb address', (t) => {
 
   t.is(eosAddress.toCKBAddress(), eosFull);
   t.is(tronAddress.toCKBAddress(), tronFull);
+});
+
+test('to ckb2021 mainnet address (Nervos RFC21)', async (t) => {
+  PWCore.chainId = ChainID.ckb;
+
+  t.is(
+    Address.fromLockScript(
+      new Script(
+        '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8',
+        '0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64',
+        HashType.type
+      ),
+      AddressPrefix.ckb
+    ).addressString,
+    new Address(
+      'ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqdnnw7qkdnnclfkg59uzn8umtfd2kwxceqxwquc4',
+      AddressType.ckb
+    ).addressString
+  );
+
+  PWCore.chainId = ChainID.ckb_testnet;
 });
 
 test('to lock script', (t) => {

--- a/src/models/address.ts
+++ b/src/models/address.ts
@@ -18,6 +18,7 @@ import ScatterJS from '@scatterjs/core';
 import { Keccak256Hasher } from '../hashers';
 import { Reader } from '../ckb-js-toolkit';
 import { Amount, AmountUnit } from './amount';
+import { scriptToAddress } from '@nervosnetwork/ckb-sdk-utils';
 
 export enum AddressPrefix {
   ckb,
@@ -47,9 +48,8 @@ export class Address {
     lockScript: Script,
     prefix: AddressPrefix = getDefaultPrefix()
   ): Address {
-    const addressString = generateAddress(lockScript.serializeJson(), {
-      config: LumosConfigs[prefix],
-    });
+    const isMainnet = prefix === AddressPrefix.ckb;
+    const addressString = scriptToAddress(lockScript, isMainnet);
 
     return new Address(addressString, AddressType.ckb);
   }

--- a/src/models/address.ts
+++ b/src/models/address.ts
@@ -20,6 +20,7 @@ import { AddressPrefix } from '@nervosnetwork/ckb-sdk-utils';
 import { Keccak256Hasher } from '../hashers';
 import { Reader } from '../ckb-js-toolkit';
 import { Amount, AmountUnit } from './amount';
+import { NervosAddressVersion } from '../helpers/address';
 
 export { AddressPrefix } from '@nervosnetwork/ckb-sdk-utils';
 
@@ -46,10 +47,11 @@ export function getDefaultPrefix(): AddressPrefix {
 export class Address {
   static fromLockScript(
     lockScript: Script,
-    prefix: AddressPrefix = getDefaultPrefix()
+    prefix: AddressPrefix = getDefaultPrefix(),
+    addressVersion = NervosAddressVersion.latest
   ): Address {
     return new Address(
-      generateCkbAddressString(lockScript, prefix),
+      generateCkbAddressString(lockScript, prefix, addressVersion),
       AddressType.ckb
     );
   }
@@ -137,12 +139,12 @@ export class Address {
     return acpLock && acpLock.length > 0;
   }
 
-  toCKBAddress(): string {
-    if (this.addressType === AddressType.ckb) {
-      return this.addressString;
-    }
-
-    return generateCkbAddressString(this.toLockScript(), getDefaultPrefix());
+  toCKBAddress(addressVersion = NervosAddressVersion.latest): string {
+    return generateCkbAddressString(
+      this.toLockScript(),
+      getDefaultPrefix(),
+      addressVersion
+    );
   }
 
   toLockScript(): Script {

--- a/src/models/script.spec.ts
+++ b/src/models/script.spec.ts
@@ -10,7 +10,7 @@ const test = anyTest as TestInterface<{
   ethLockScript: Script;
 }>;
 const address = new Address(
-  'ckt1qyqxpayn272n8km2k08hzldynj992egs0waqnr8zjs',
+  'ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqtq7jf409fnmd4t8nm30kjfezj4v5g8hwskhal6m',
   AddressType.ckb
 );
 const defaultLockscriptHash =

--- a/src/models/script.ts
+++ b/src/models/script.ts
@@ -1,11 +1,6 @@
 import { HashType, CKBModel } from '../interfaces';
-import {
-  Address,
-  AddressType,
-  AddressPrefix,
-  getDefaultPrefix,
-} from './address';
-import { generateAddress, LumosConfigs } from '../utils';
+import { Address, AddressType, getDefaultPrefix } from './address';
+import { generateCkbAddressString } from '../utils';
 import { validators, transformers, normalizers } from '../ckb-js-toolkit';
 import { SerializeScript } from '../ckb-lumos/core';
 import { Blake2bHasher } from '../hashers';
@@ -56,11 +51,7 @@ export class Script implements CKBModel {
       .serializeJson();
   }
 
-  toAddress(prefix: AddressPrefix = getDefaultPrefix()): Address {
-    const address = generateAddress(this.serializeJson(), {
-      config: LumosConfigs[prefix],
-    });
-
-    return new Address(address, AddressType.ckb);
+  toAddress(prefix = getDefaultPrefix()): Address {
+    return new Address(generateCkbAddressString(this, prefix), AddressType.ckb);
   }
 }

--- a/src/models/script.ts
+++ b/src/models/script.ts
@@ -4,6 +4,7 @@ import { generateCkbAddressString } from '../utils';
 import { validators, transformers, normalizers } from '../ckb-js-toolkit';
 import { SerializeScript } from '../ckb-lumos/core';
 import { Blake2bHasher } from '../hashers';
+import { NervosAddressVersion } from '../helpers/address';
 
 export class Script implements CKBModel {
   static fromRPC(data: any): Script | undefined {
@@ -51,7 +52,13 @@ export class Script implements CKBModel {
       .serializeJson();
   }
 
-  toAddress(prefix = getDefaultPrefix()): Address {
-    return new Address(generateCkbAddressString(this, prefix), AddressType.ckb);
+  toAddress(
+    prefix = getDefaultPrefix(),
+    addressVersion = NervosAddressVersion.latest
+  ): Address {
+    return new Address(
+      generateCkbAddressString(this, prefix, addressVersion),
+      AddressType.ckb
+    );
   }
 }

--- a/src/providers/raw-provider.ts
+++ b/src/providers/raw-provider.ts
@@ -1,14 +1,6 @@
 import { Platform, Provider } from './provider';
-import {
-  Address,
-  AddressType,
-  getDefaultPrefix,
-  AddressPrefix as PwAddressPrefix,
-} from '../models';
-import {
-  AddressPrefix,
-  privateKeyToAddress,
-} from '@nervosnetwork/ckb-sdk-utils';
+import { Address, AddressType, getDefaultPrefix } from '../models';
+import { privateKeyToAddress } from '@nervosnetwork/ckb-sdk-utils';
 import { Blake2bHasher, Hasher } from '../hashers';
 import ECPair from '@nervosnetwork/ckb-sdk-utils/lib/ecpair';
 
@@ -20,11 +12,8 @@ export class RawProvider extends Provider {
   }
 
   async init(): Promise<Provider> {
-    const pwPrefix = getDefaultPrefix();
-    const prefix =
-      pwPrefix === PwAddressPrefix.ckb
-        ? AddressPrefix.Mainnet
-        : AddressPrefix.Testnet;
+    const prefix = getDefaultPrefix();
+
     const address = privateKeyToAddress(this.privateKey, { prefix });
     this.address = new Address(address, AddressType.ckb);
     return this;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,13 @@
 import JSBI from 'jsbi';
 import { bech32, bech32m } from 'bech32';
-import { FormatOptions } from '.';
+import { FormatOptions, Script } from '.';
 import Decimal from 'decimal.js';
-import { addressToScript, AddressType } from '@nervosnetwork/ckb-sdk-utils';
+import {
+  AddressPrefix,
+  addressToScript,
+  AddressType,
+  scriptToAddress,
+} from '@nervosnetwork/ckb-sdk-utils';
 
 const BECH32_LIMIT = 1023;
 
@@ -202,23 +207,18 @@ export function hexToByteArray(h: string) {
   return array;
 }
 
-export function generateAddress(script: any, { config = LINA } = {}): string {
-  const scriptTemplate = Object.values(config.SCRIPTS).find(
-    (s) =>
-      s.SCRIPT.code_hash === script.code_hash &&
-      s.SCRIPT.hash_type === script.hash_type
-  );
-  const data = [];
-  if (scriptTemplate && scriptTemplate.SHORT_ID !== undefined) {
-    data.push(1, scriptTemplate.SHORT_ID);
-    data.push(...hexToByteArray(script.args));
-  } else {
-    data.push(script.hash_type === 'type' ? 4 : 2);
-    data.push(...hexToByteArray(script.code_hash));
-    data.push(...hexToByteArray(script.args));
-  }
-  const words = bech32.toWords(data);
-  return bech32.encode(config.PREFIX, words, BECH32_LIMIT);
+export function getLumosConfigByNetworkPrefix(networkPrefix: AddressPrefix) {
+  return LumosConfigs.find((c) => c.PREFIX === networkPrefix);
+}
+
+export function generateCkbAddressString(
+  lockScript: Script,
+  networkPrefix: AddressPrefix
+) {
+  const isMainnet = networkPrefix === AddressPrefix.Mainnet;
+  const addressString = scriptToAddress(lockScript, isMainnet);
+
+  return addressString;
 }
 
 export function parseAddress(address: string, { config = LINA } = {}) {


### PR DESCRIPTION
1. [BREAKING CHANGE] Layer 1 CKB2021 upgrade compatibility in respect with RFC21 https://github.com/nervosnetwork/rfcs/pull/239 for address generation
2. [BREAKING CHANGE] Remove custom enum AddressPrefix in favour of using ckb-sdk-js AddressPrefix enum (reduces confusion to just use one)
3. `Address.toCKBAddress()` now accepts `NervosAddressVersion` enum which specifies whether you want to generate CKB2021 or pre-CKB2021 address
4. `Script.toAddress()` now accepts `NervosAddressVersion` enum which specifies whether you want to generate CKB2021 or pre-CKB2021 address
5. Fix tests by changing used EOS mainneet node

Backwards compatibility: After this PR pw-core will support parsing old addresses. Each time you call toCKBAddress() without arguments it will generate CKB2021 RFC21 address. If you pass `NervosAddressVersion.pre2021` you can generate old version of the address.

Related to:
https://github.com/lay2dev/pw-core/issues/25

CKB2021 reference:
1. https://github.com/nervosnetwork/rfcs/pull/239/files

![image](https://user-images.githubusercontent.com/4950658/150373926-c1ae3b0e-2f58-4b47-90f6-641af0e71b9b.png)
